### PR TITLE
Support for PyMuPdf v1.25.1 (definitive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
     <img src="https://raw.githubusercontent.com/AstraBert/PdfItDown/main/logo.png" alt="PdfItDown Logo">
 </div>
 
-**PdfItDown** is a python package that relies on [`markitdown` by Microsoft](https://github.com/microsoft/markitdown/) and [`markdown_pdf`](https://github.com/vb64/markdown-pdf). 
+> [!IMPORTANT]
+> `markdown-pdf` is now implemented, with support for `PyMuPdf` v1.25.1, internally in `PdfItDown`. Make sure to install the latest version of the package (from 0.0.4 on) to avoid errors such as the one in [this issue](https://github.com/AstraBert/PdfItDown/issues/1) 
+
+**PdfItDown** is a python package that relies on [`markitdown` by Microsoft](https://github.com/microsoft/markitdown/) and (a slightly modified version of) [`markdown_pdf`](https://github.com/vb64/markdown-pdf). 
 
 ### Applicability
 
@@ -93,22 +96,6 @@ output_pdf = convert_markdown_to_pdf(file_path = "BusinessGrowth.md", output_pat
 
 In these examples, you will find the output PDF under `business_growth.pdf`.
 
-### Troubleshooting
-
-If you encounter a segmentation fault error like in [this issue](https://github.com/AstraBert/PdfItDown/issues/1), please consider the following option:
-
-```bash
-git clone https://github.com/AstraBert/PdfItDown.git
-cd PdfItDown
-python3 -m build
-python3 -m venv virtualenv
-source virtualenv/bin/activate
-python3 -m pip install -r requirements.txt
-python3 -m pip install .
-```
-
-> [!IMPORTANT]
-> This is just a temporary fix, until `markdown-pdf` does not resolve the issue itself by implementing a newer version of PyMuPdf. See [this issue](https://github.com/vb64/markdown-pdf/issues/38) for reference
 
 ### Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdfitdown"
-version = "0.0.3.post1"
+version = "0.0.4"
 authors = [
     { name="Clelia (Astra) Bertelli", email="astraberte9@gmail.com" },
 ]
@@ -18,7 +18,8 @@ classifiers = [
 ]
 dependencies = [
     'markitdown',
-    'markdown_pdf == 1.3.2',
+    'markdown_it_py == 3.0.0',
+    'pymupdf == 1.25.1',
     'termcolor',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pymupdf==1.25.1
 markdown-it-py==3.0.0
-markdown_pdf==1.3.2 --no-deps
 markitdown
 termcolor

--- a/src/pdfitdown/markdown_pdf.py
+++ b/src/pdfitdown/markdown_pdf.py
@@ -1,0 +1,94 @@
+"""Markdown to pdf converter based on markdown_it and fitz."""
+import io
+import typing
+import pathlib
+from markdown_it import MarkdownIt
+import fitz
+
+
+class Section:
+    """Markdown section."""
+
+    def __init__(
+      self,
+      text: str,
+      toc: bool = True,
+      root: str = ".",
+      paper_size: str = "A4",
+      borders: tuple = (36, 36, -36, -36)
+    ):
+        """Create md section with given properties."""
+        self.text = text
+        self.toc = toc
+        self.root = root
+        # https://pymupdf.readthedocs.io/en/latest/functions.html#paper_size
+        self.paper_size = paper_size
+        self.borders = borders
+
+
+class MarkdownPdf:
+    """Converter class."""
+
+    meta = {
+      "creationDate": fitz.get_pdf_now(),
+      "modDate": fitz.get_pdf_now(),
+      "creator": "PyMuPDF library: https://pypi.org/project/PyMuPDF",
+      "producer": None,
+      "title": None,
+      "author": None,
+      "subject": None,
+      "keywords": None,
+    }
+
+    def __init__(self, toc_level: int = 6, mode: str = 'commonmark'):
+        """Create md -> pdf converter with given TOC level and mode of md parsing."""
+        self.toc_level = toc_level
+        self.toc = []
+
+        # zero, commonmark, js-default, gfm-like
+        # https://markdown-it-py.readthedocs.io/en/latest/using.html#quick-start
+        self.m_d = (MarkdownIt(mode).enable('table'))  # Enable support for tables
+
+        self.out_file = io.BytesIO()
+        self.writer = fitz.DocumentWriter(self.out_file)
+        self.page = 0
+
+    @staticmethod
+    def _recorder(elpos):
+        """Call function invoked during story.place() for making a TOC."""
+        if not elpos.open_close & 1:  # only consider "open" items
+            return
+        if not elpos.toc:
+            return
+
+        if 0 < elpos.heading <= elpos.pdfile.toc_level:  # this is a header (h1 - h6)
+            elpos.pdfile.toc.append((
+                elpos.heading,
+                elpos.text,
+                elpos.pdfile.page,
+                elpos.rect[1],  # top of written rectangle (use for TOC)
+            ))
+
+    def add_section(self, section: Section, user_css: typing.Optional[str] = None) -> None:
+        """Add markdown section to pdf."""
+        rect = fitz.paper_rect(section.paper_size)
+        where = rect + section.borders
+        story = fitz.Story(html=self.m_d.render(section.text), archive=section.root, user_css=user_css)
+        more = 1
+        while more:  # loop outputting the story
+            self.page += 1
+            device = self.writer.begin_page(rect)
+            more, _ = story.place(where)  # layout into allowed rectangle
+            story.element_positions(self._recorder, {"toc": section.toc, "pdfile": self})
+            story.draw(device)
+            self.writer.end_page()
+
+    def save(self, file_name: typing.Union[str, pathlib.Path]) -> None:
+        """Save pdf to file."""
+        self.writer.close()
+        doc = fitz.open("pdf", self.out_file)
+        doc.set_metadata(self.meta)
+        if self.toc_level > 0:
+            doc.set_toc(self.toc)
+        doc.save(file_name)
+        doc.close()

--- a/src/pdfitdown/pdfconversion.py
+++ b/src/pdfitdown/pdfconversion.py
@@ -1,6 +1,9 @@
 # Import required libraries
 from markitdown import MarkItDown          # Library for conversion to markdown
-from markdown_pdf import MarkdownPdf, Section  # Library for PDF generation
+try:
+    from .markdown_pdf import MarkdownPdf, Section  # Library for PDF generation
+except ImportError:
+    from markdown_pdf import MarkdownPdf, Section
 
 def convert_to_pdf(
     file_path: str,     # Path to input file


### PR DESCRIPTION
- Implemented `markdown-pdf` directly in `pdfitdown` with support for `PyMuPdf` v1.25.1, closes #4