### PR TITLE
fix: use Path.with_suffix for generated PDF paths

### DIFF
--- a/src/pdfitdown/cli/app.py
+++ b/src/pdfitdown/cli/app.py
@@ -55,7 +55,7 @@ def main(
             )
         if len(inputfile) == 1:
             if len(outputfile) == 0:
-                outputfile = [inputfile[0].replace(Path(inputfile[0]).suffix, ".pdf")]
+                outputfile = [str(Path(inputfile[0]).with_suffix(".pdf"))]
             try:
                 c.convert(inputfile[0], outputfile[0], title, True)
             except Exception as e:

--- a/src/pdfitdown/pdfconversion/models.py
+++ b/src/pdfitdown/pdfconversion/models.py
@@ -190,12 +190,12 @@ class MultipleConversion:
             for root, _, files in os.walk(directory.path):
                 if files:
                     for file in files:
-                        if (suffix := Path(file).suffix) != ".pdf":
+                        if Path(file).suffix != ".pdf":
                             ifl = OsPath.from_file(
                                 os.path.join(root, file), directory.overwrite, True
                             )
                             ofl = OsPath.from_file(
-                                os.path.join(root, file.replace(suffix, ".pdf")),
+                                str(Path(os.path.join(root, file)).with_suffix(".pdf")),
                                 directory.overwrite,
                                 False,
                             )
@@ -203,7 +203,7 @@ class MultipleConversion:
                             outpt_files.append(ofl)
         else:
             for fl in os.listdir(directory.path):
-                if Path(fl).is_file() and (suffix := Path(fl).suffix) != ".pdf":
+                if Path(fl).is_file() and Path(fl).suffix != ".pdf":
                     inpt_files.append(
                         OsPath.from_file(
                             os.path.join(directory.path, fl), directory.overwrite, True
@@ -211,7 +211,11 @@ class MultipleConversion:
                     )
                     outpt_files.append(
                         OsPath.from_file(
-                            os.path.join(directory.path, fl.replace(suffix, ".pdf")),
+                            str(
+                                Path(os.path.join(directory.path, fl)).with_suffix(
+                                    ".pdf"
+                                )
+                            ),
                             directory.overwrite,
                             True,
                         )
@@ -239,9 +243,11 @@ class MultipleConversion:
         inpt_files: list[OsPath] = []
         outpt_files: list[OsPath] = []
         for file in input_files:
-            if (suffix := Path(file).suffix) != ".pdf":
+            if Path(file).suffix != ".pdf":
                 ifl = OsPath.from_file(file, overwrite, True)
-                ofl = OsPath.from_file(file.replace(suffix, ".pdf"), overwrite, False)
+                ofl = OsPath.from_file(
+                    str(Path(file).with_suffix(".pdf")), overwrite, False
+                )
                 inpt_files.append(ifl)
                 outpt_files.append(ofl)
         return cls(input_files=inpt_files, output_files=outpt_files)

--- a/src/pdfitdown/server/serve.py
+++ b/src/pdfitdown/server/serve.py
@@ -65,7 +65,7 @@ if STARLETTE_AVAILABLE:
                 tmp = os.path.join(temp_dir, file_name)
                 with open(tmp, "wb") as f:
                     f.write(file_content)
-                output_filename = file_name.replace(Path(file_name).suffix, ".pdf")
+                output_filename = str(Path(file_name).with_suffix(".pdf"))
                 output_path = os.path.join(temp_dir, output_filename)
                 try:
                     converter.convert(tmp, output_path)

--- a/tests/test_custom_conversion_callback.py
+++ b/tests/test_custom_conversion_callback.py
@@ -91,23 +91,19 @@ def test_conversion_callback_multiple_files(
     converter = Converter(conversion_callback=custom_conversion_callback)
     input_files = [image_file, to_convert_file]
     converter.multiple_convert(file_paths=input_files)
-    assert CONVERTED_FILES[image_file] == image_file.replace(
-        Path(image_file).suffix, ".pdf"
-    )
-    assert CONVERTED_FILES[to_convert_file] == to_convert_file.replace(
-        Path(to_convert_file).suffix, ".pdf"
+    assert CONVERTED_FILES[image_file] == str(Path(image_file).with_suffix(".pdf"))
+    assert CONVERTED_FILES[to_convert_file] == str(
+        Path(to_convert_file).with_suffix(".pdf")
     )
     assert CONVERTED_TITLES.count("No title") == 2
     output_files = [
-        image_file.replace(Path(image_file).suffix, ".1.pdf"),
-        to_convert_file.replace(Path(to_convert_file).suffix, ".1.pdf"),
+        str(Path(image_file).with_suffix(".1.pdf")),
+        str(Path(to_convert_file).with_suffix(".1.pdf")),
     ]
     converter.multiple_convert(file_paths=input_files, output_paths=output_files)
-    assert CONVERTED_FILES[image_file] == image_file.replace(
-        Path(image_file).suffix, ".1.pdf"
-    )
-    assert CONVERTED_FILES[to_convert_file] == to_convert_file.replace(
-        Path(to_convert_file).suffix, ".1.pdf"
+    assert CONVERTED_FILES[image_file] == str(Path(image_file).with_suffix(".1.pdf"))
+    assert CONVERTED_FILES[to_convert_file] == str(
+        Path(to_convert_file).with_suffix(".1.pdf")
     )
     assert CONVERTED_TITLES.count("No title") == 4
     with pytest.raises(FileExistsError, match="Cannot overwrite file"):
@@ -139,6 +135,6 @@ def test_conversion_callback_directory(
         ]
     )
     for file in CONVERTED_FILES:
-        assert CONVERTED_FILES[file] == file.replace(Path(file).suffix, ".pdf")
+        assert CONVERTED_FILES[file] == str(Path(file).with_suffix(".pdf"))
     with pytest.raises(FileExistsError, match="Cannot overwrite file"):
         converter.convert_directory(directory_path=to_convert_dir, overwrite=False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -150,7 +150,7 @@ def test_multipleconversion_validation(all_files: list[str]) -> None:
     ]
     all_files_output = [
         OsPath.from_file(
-            file.replace(Path(file).suffix, ".pdf"), overwrite=True, is_input=False
+            str(Path(file).with_suffix(".pdf")), overwrite=True, is_input=False
         )
         for file in all_files
     ]
@@ -170,7 +170,7 @@ def test_multipleconversion_from_list(all_files: list[str]) -> None:
     ]
     all_files_output = [
         OsPath.from_file(
-            file.replace(Path(file).suffix, ".pdf"), overwrite=True, is_input=False
+            str(Path(file).with_suffix(".pdf")), overwrite=True, is_input=False
         )
         for file in all_files
     ]
@@ -193,3 +193,23 @@ def test_multipleconversion_from_dir(
         assert fl.path.endswith(".pdf")
         assert fl.type == "outputfile"
     assert len(mc.input_files) == len(all_files)
+
+
+def test_output_path_with_repeated_suffix(tmp_path: Path) -> None:
+    """Ensure output paths handle filenames containing the suffix string multiple times."""
+    # Create an input file with a suffix repeated in its name
+    input_file = tmp_path / "report.docx.backup.docx"
+    input_file.touch()
+
+    # Also create a directory whose name contains the suffix
+    nested_dir = tmp_path / ".docx_configs"
+    nested_dir.mkdir()
+    input_file_in_dir = nested_dir / "data.docx"
+    input_file_in_dir.touch()
+
+    # Test from_input_files
+    mc1 = MultipleConversion.from_input_files([str(input_file)], overwrite=True)
+    assert mc1.output_files[0].path == str(tmp_path / "report.docx.backup.pdf")
+
+    mc2 = MultipleConversion.from_input_files([str(input_file_in_dir)], overwrite=True)
+    assert mc2.output_files[0].path == str(nested_dir / "data.pdf")


### PR DESCRIPTION
## Problem

Generated PDF output paths were built with `str.replace(suffix, ".pdf")`.

`str.replace()` performs substring replacement on the whole string, so it can modify more than the final file extension when the suffix appears earlier in the path.

Examples:
```python
"/data/.json_configs/config.json".replace(".json", ".pdf")
# "/data/.pdf_configs/config.pdf"

"report.docx.backup.docx".replace(".docx", ".pdf")
# "report.pdf.backup.pdf"

Solution
Use Path.with_suffix(".pdf") when generating PDF output paths.

This changes only the final path suffix and preserves the rest of the path.

Changes
Updated generated output paths in:
src/pdfitdown/pdfconversion/models.py
src/pdfitdown/cli/app.py
src/pdfitdown/server/serve.py

Updated test expectations to avoid duplicating the old str.replace() behavior.

Added regression coverage for repeated suffixes in filenames and suffix-like text in parent directories.

Validation
uv run --all-groups --all-extras pytest tests  (31 passed)
uv run --all-groups --all-extras ruff format --check (Passed)
uv run --all-groups --all-extras ruff check  (Passed)